### PR TITLE
Adding logging in console if something goes wrong

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -43,6 +43,7 @@ var setBubble = function(req, res){
 
     bubble.save(function (err, data) {
         if (!err){
+            console.log(arguments);
             res.jsonp(data);
         }
     });


### PR DESCRIPTION
Could be useful, when you are connected to mongoDb, but have no right to write in it. Console log will return correct error instead of 'Error: timeout'.